### PR TITLE
Rust upgrade (seems to need a Clone with a Copy).

### DIFF
--- a/maud_macros/src/render.rs
+++ b/maud_macros/src/render.rs
@@ -6,7 +6,7 @@ use syntax::ptr::P;
 
 use maud;
 
-#[derive(Copy)]
+#[derive(Copy,Clone)]
 pub enum Escape {
     PassThru,
     Escape,


### PR DESCRIPTION
Rust seems to need this now.
rustc 1.0.0-nightly (d17d6e7f1 2015-04-02) (built 2015-04-03)