### PR TITLE
Allow path lookups in un-delimited splices

### DIFF
--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -32,6 +32,9 @@ macro_rules! pound {
 macro_rules! dot {
     () => (TokenTree::Token(_, Token::Dot))
 }
+macro_rules! modsep {
+    () => (TokenTree::Token(_, Token::ModSep))
+}
 macro_rules! eq {
     () => (TokenTree::Token(_, Token::Eq))
 }
@@ -326,6 +329,12 @@ impl<'cx, 'i> Parser<'cx, 'i> {
             [ref dot @ dot!(), ref ident @ ident!(_, _), ..] => {
                 self.shift(2);
                 tts.push(dot.clone());
+                tts.push(ident.clone());
+            },
+            // Munch path lookups e.g. `$some_mod::Struct`
+            [ref sep @ modsep!(), ref ident @ ident!(_, _), ..] => {
+                self.shift(2);
+                tts.push(sep.clone());
                 tts.push(ident.clone());
             },
             // Munch function calls `()` and indexing operations `[]`

--- a/maud_macros/tests/tests.rs
+++ b/maud_macros/tests/tests.rs
@@ -309,3 +309,17 @@ fn issue_23() {
     let s = to_string!(p { "Hi, " $name "!" });
     assert_eq!(s, "<p>Hi, Lyra!</p>");
 }
+
+#[test]
+fn splice_with_path() {
+    mod inner {
+        pub fn name() -> &'static str {
+            "Rusticle"
+        }
+    }
+
+    let mut s = String::new();
+    html!(s, $inner::name()).unwrap();
+    assert_eq!(s, "Rusticle");
+}
+


### PR DESCRIPTION
Makes it easier when you want to reference structs/functions in other modules without importing them into the local context. E.g. just using `html!(w, $maud::PreEscaped("value"))` instead of having to `use maud::PreEscaped`.