### PR TITLE
Add a shorthand syntax to define element classes

### DIFF
--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -394,11 +394,7 @@ impl<'cx, 'i> Parser<'cx, 'i> {
         }
         if !classes.is_empty() {
             self.render.attribute_start("class");
-            let mut s = String::new();
-            for class in classes {
-              s = s + &*class + " ";
-            }
-            self.render.string(s.trim());
+            self.render.string(&classes.join(" "));
             self.render.attribute_end();
         }
         Ok(())

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -190,10 +190,6 @@ impl<'cx, 'i> Parser<'cx, 'i> {
                 let name = try!(self.name());
                 try!(self.element(sp, &name));
             },
-            // Shorthand div element
-            [dot!(), ident!(sp, _), ..] => {
-                try!(self.element(sp, "div"));
-            },
             // Block
             [TokenTree::Delimited(_, ref d), ..] if d.delim == DelimToken::Brace => {
                 self.shift(1);

--- a/maud_macros/tests/tests.rs
+++ b/maud_macros/tests/tests.rs
@@ -339,10 +339,10 @@ fn class_shorthand() {
 }
 
 #[test]
-fn div_class_shorthand() {
+fn class_shorthand_with_space() {
     let mut s = String::new();
-    html!(s, p { "Hi, " .name { "Lyra" } "!" }).unwrap();
-    assert_eq!(s, "<p>Hi, <div class=\"name\">Lyra</div>!</p>");
+    html!(s, p { "Hi, " span .name { "Lyra" } "!" }).unwrap();
+    assert_eq!(s, "<p>Hi, <span class=\"name\">Lyra</span>!</p>");
 }
 
 #[test]
@@ -353,15 +353,15 @@ fn classes_shorthand() {
 }
 
 #[test]
-fn div_classes_shorthand() {
+fn classes_shorthand_with_space() {
     let mut s = String::new();
-    html!(s, p { "Hi, " .name.here { "Lyra" } "!" }).unwrap();
-    assert_eq!(s, "<p>Hi, <div class=\"name here\">Lyra</div>!</p>");
+    html!(s, p { "Hi, " span .name .here { "Lyra" } "!" }).unwrap();
+    assert_eq!(s, "<p>Hi, <span class=\"name here\">Lyra</span>!</p>");
 }
 
 #[test]
-fn div_classes_shorthand_with_attrs() {
+fn classes_shorthand_with_attrs() {
     let mut s = String::new();
-    html!(s, p { "Hi, " .name.here id="thing" { "Lyra" } "!" }).unwrap();
-    assert_eq!(s, "<p>Hi, <div class=\"name here\" id=\"thing\">Lyra</div>!</p>");
+    html!(s, p { "Hi, " span.name.here id="thing" { "Lyra" } "!" }).unwrap();
+    assert_eq!(s, "<p>Hi, <span class=\"name here\" id=\"thing\">Lyra</span>!</p>");
 }

--- a/maud_macros/tests/tests.rs
+++ b/maud_macros/tests/tests.rs
@@ -330,3 +330,38 @@ fn splice_with_path() {
     html!(s, $inner::name()).unwrap();
     assert_eq!(s, "Maud");
 }
+
+#[test]
+fn class_shorthand() {
+    let mut s = String::new();
+    html!(s, p { "Hi, " span.name { "Lyra" } "!" }).unwrap();
+    assert_eq!(s, "<p>Hi, <span class=\"name\">Lyra</span>!</p>");
+}
+
+#[test]
+fn div_class_shorthand() {
+    let mut s = String::new();
+    html!(s, p { "Hi, " .name { "Lyra" } "!" }).unwrap();
+    assert_eq!(s, "<p>Hi, <div class=\"name\">Lyra</div>!</p>");
+}
+
+#[test]
+fn classes_shorthand() {
+    let mut s = String::new();
+    html!(s, p { "Hi, " span.name.here { "Lyra" } "!" }).unwrap();
+    assert_eq!(s, "<p>Hi, <span class=\"name here\">Lyra</span>!</p>");
+}
+
+#[test]
+fn div_classes_shorthand() {
+    let mut s = String::new();
+    html!(s, p { "Hi, " .name.here { "Lyra" } "!" }).unwrap();
+    assert_eq!(s, "<p>Hi, <div class=\"name here\">Lyra</div>!</p>");
+}
+
+#[test]
+fn div_classes_shorthand_with_attrs() {
+    let mut s = String::new();
+    html!(s, p { "Hi, " .name.here id="thing" { "Lyra" } "!" }).unwrap();
+    assert_eq!(s, "<p>Hi, <div class=\"name here\" id=\"thing\">Lyra</div>!</p>");
+}


### PR DESCRIPTION
This is similar to how [slim](http://slim-lang.com) works, very useful when you're using a class heavy css framework. An example from the bootstrap docs

```
div class="input-group" {
  span class="input-group-addon" { "$" }
  input type="text" class="form-control" aria-label="Amount (to the nearest dollar)" { }
  span class="input-group-addon" { ".00" } 
}
```

becomes

```
.input-group {
  span.input-group-addon { "$" }
  input.form-control type="text" aria-label="Amount (to the nearest dollar)" { }
  span.input-group-addon { ".00" } 
}
```