### PR TITLE
Speed up `std::fmt::Write::write_str` for `maud::Escaper`.

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -176,14 +176,28 @@ impl<'a> Escaper<'a> {
 
 impl<'a> fmt::Write for Escaper<'a> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        for b in s.bytes() {
-            match b {
-                b'&' => self.0.push_str("&amp;"),
-                b'<' => self.0.push_str("&lt;"),
-                b'>' => self.0.push_str("&gt;"),
-                b'"' => self.0.push_str("&quot;"),
-                _ => unsafe { self.0.as_mut_vec().push(b) },
+        let bytes = s.as_bytes();
+        let mut last = 0;
+        for (i, &b) in bytes.iter().enumerate() {
+            macro_rules! push {
+                ($str:expr) => {{
+                    unsafe {
+                        self.0.as_mut_vec().extend_from_slice(&bytes[last..i]);
+                    }
+                    self.0.push_str($str);
+                    last = i + 1;
+                }}
             }
+            match b {
+                b'&' => push!("&amp;"),
+                b'<' => push!("&lt;"),
+                b'>' => push!("&gt;"),
+                b'"' => push!("&quot;"),
+                _ => {}
+            }
+        }
+        unsafe {
+            self.0.as_mut_vec().extend_from_slice(&bytes[last..]);
         }
         Ok(())
     }


### PR DESCRIPTION
I'm seeing roughly 25% speedup on both the normal and complicated
benchmarks present in `benchmarks/benches/maud.rs` and
`benchmarks/benches/complicated_maud.rs` respectively.

Before:

    test render_template ... bench:             461 ns/iter (+/- 140)
    test render_complicated_template ... bench: 1,562 ns/iter (+/- 366)

After:

    test render_template ... bench:             350 ns/iter (+/- 69)
    test render_complicated_template ... bench: 1,145 ns/iter (+/- 633)

(The error margins are pretty high in the above snippets but I've
ran these benchmarks several times and the difference is consistent.)

<hr>

What do you think @lfairy?

I also tried using `str::slice_unchecked` (there is no easy way to do unchecked slicing for slices yet; see https://github.com/rust-lang/rust/issues/35729) but there was no measurable improvement.