### PR TITLE
Features/add meta tags to maud extras

### DIFF
--- a/maud_extras/lib.rs
+++ b/maud_extras/lib.rs
@@ -108,3 +108,29 @@ impl<T: AsRef<str>> Render for Title<T> {
         }
     }
 }
+
+/// Generate <meta charset=""> element.
+///
+/// # Example
+///
+/// ```rust
+/// # #![feature(plugin)]
+/// # #![plugin(maud_macros)]
+/// # extern crate maud;
+/// # extern crate maud_extras;
+/// # use maud_extras::*;
+/// # fn main() {
+/// let markup = html! { (Charset("utf-8")) };
+/// assert_eq!(markup.into_string(),
+///            r#"<meta charset="utf-8">"#);
+/// # }
+/// ```
+pub struct Charset<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> Render for Charset<T> {
+    fn render(&self) -> Markup {
+        html! {
+            meta charset=(self.0.as_ref()) /
+        }
+    }
+}

--- a/maud_extras/lib.rs
+++ b/maud_extras/lib.rs
@@ -82,3 +82,29 @@ impl<T: AsRef<str>, U: AsRef<str>> Render for Meta<T, U> {
         }
     }
 }
+
+/// Generate <title> element.
+///
+/// # Example
+///
+/// ```rust
+/// # #![feature(plugin)]
+/// # #![plugin(maud_macros)]
+/// # extern crate maud;
+/// # extern crate maud_extras;
+/// # use maud_extras::*;
+/// # fn main() {
+/// let markup = html! { (Title("Maud")) };
+/// assert_eq!(markup.into_string(),
+///            r#"<title>Maud</title>"#);
+/// # }
+/// ```
+pub struct Title<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> Render for Title<T> {
+    fn render(&self) -> Markup {
+        html! {
+            title (self.0.as_ref())
+        }
+    }
+}

--- a/maud_extras/lib.rs
+++ b/maud_extras/lib.rs
@@ -56,3 +56,29 @@ impl<T: AsRef<str>> Render for Js<T> {
         }
     }
 }
+
+/// Generate <meta> elements.
+///
+/// # Example
+///
+/// ```rust
+/// # #![feature(plugin)]
+/// # #![plugin(maud_macros)]
+/// # extern crate maud;
+/// # extern crate maud_extras;
+/// # use maud_extras::*;
+/// # fn main() {
+/// let m = Meta("description", "test description");
+/// assert_eq!(html!{ (m) }.into_string(),
+///            r#"<meta name="description" content="test description">"#);
+/// # }
+/// ```
+pub struct Meta<T: AsRef<str>, U: AsRef<str>>(pub T, pub U);
+
+impl<T: AsRef<str>, U: AsRef<str>> Render for Meta<T, U> {
+    fn render(&self) -> Markup {
+        html! {
+            meta name=(self.0.as_ref()) content=(self.1.as_ref()) /
+        }
+    }
+}

--- a/maud_extras/lib.rs
+++ b/maud_extras/lib.rs
@@ -30,3 +30,29 @@ impl<T: AsRef<str>> Render for Css<T> {
         }
     }
 }
+
+/// Links to an external javascript.
+///
+/// # Example
+///
+/// ```rust
+/// # #![feature(plugin)]
+/// # #![plugin(maud_macros)]
+/// # extern crate maud;
+/// # extern crate maud_extras;
+/// # use maud_extras::*;
+/// # fn main() {
+/// let markup = html! { (Js("app.js")) };
+/// assert_eq!(markup.into_string(),
+///            r#"<script src="app.js"></script>"#);
+/// # }
+/// ```
+pub struct Js<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> Render for Js<T> {
+    fn render(&self) -> Markup {
+        html! {
+            script src=(self.0.as_ref()) {}
+        }
+    }
+}


### PR DESCRIPTION
1. Locking Cargo dependencies since master has [build error] it becomes tedious to work with maud_extras crate.

2. Adding Javascript element analogous to Css

3. Adding meta tags struct which generate <title> and meta description

I have Form struct ready, will add in a few days.