### PR TITLE
Adjust to make compatible with current `libsyntax`

### DIFF
--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -369,9 +369,7 @@ impl<'cx, 'a, 'i> Parser<'cx, 'a, 'i> {
                 self.shift(1);
                 bodies.push(tt.clone());
             },
-            [TokenTree::Token(sp, _), ..] | [TokenTree::Delimited(sp, _), ..] => {
-                bodies.append(&mut self.match_body(sp)?);
-            },
+			[ref tt, ..] => bodies.append(&mut self.match_body(tt.span())?),
         }}
         Ok(bodies)
     }

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -204,7 +204,7 @@ impl<'cx, 'a, 'i> Parser<'cx, 'a, 'i> {
             // ???
             _ => {
                 if let [ref tt, ..] = *self.input {
-                    parse_error!(self, tt.get_span(), "invalid syntax");
+                    parse_error!(self, tt.span(), "invalid syntax");
                 } else {
                     parse_error!(self, self.span, "unexpected end of block");
                 }
@@ -369,7 +369,7 @@ impl<'cx, 'a, 'i> Parser<'cx, 'a, 'i> {
                 self.shift(1);
                 bodies.push(tt.clone());
             },
-            [TokenTree::Token(sp, _), ..] | [TokenTree::Delimited(sp, _), ..] | [TokenTree::Sequence(sp, _), ..] => {
+            [TokenTree::Token(sp, _), ..] | [TokenTree::Delimited(sp, _), ..] => {
                 bodies.append(&mut self.match_body(sp)?);
             },
         }}


### PR DESCRIPTION
Was broken since `rustc` nightly 2017-03-01.
Fixes #77.