### PR TITLE
Update to Rocket 0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased] - 2017-07-14
+
+- [Changed] Update to Rocket 0.3
+
 ## [0.16.3] - 2017-04-22
 
 - [Fixed] Update to rustc 1.18.0-nightly (1785bca51 2017-04-21)
@@ -127,7 +131,8 @@
 - [Fixed] Update to latest syntax extension API
 
 
-[Unreleased]: https://github.com/lfairy/maud/compare/v0.16.2...HEAD
+[Unreleased]: https://github.com/lfairy/maud/compare/v0.16.3...HEAD
+[0.16.3]: https://github.com/lfairy/maud/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/lfairy/maud/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/lfairy/maud/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/lfairy/maud/compare/v0.15.0...v0.16.0

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["template-engine"]
 
 [dependencies]
 iron = { version = "0.5.1", optional = true }
-rocket = { version = ">= 0.1.2, < 0.3", optional = true }
+rocket = { version = "0.3", optional = true }
 
 [badges]
 travis-ci = { repository = "lfairy/maud" }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -214,12 +214,13 @@ mod iron_support {
 #[cfg(feature = "rocket")]
 mod rocket_support {
     use rocket::http::{ContentType, Status};
+    use rocket::request::Request;
     use rocket::response::{Responder, Response};
     use std::io::Cursor;
     use PreEscaped;
 
     impl Responder<'static> for PreEscaped<String> {
-        fn respond(self) -> Result<Response<'static>, Status> {
+        fn respond_to(self, _: &Request) -> Result<Response<'static>, Status> {
             Response::build()
                 .header(ContentType::HTML)
                 .sized_body(Cursor::new(self.0))


### PR DESCRIPTION
Also fixes diff links in CHANGELOG.md. Releasing would require bumping `maud` and `maud_macros` to 0.17.0 due to `Responder::respond(self)` becoming `Responder::respond_to(self, &Request)`.