### PR TITLE
Port to new proc macro interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,12 @@ script:
       printf 'Checking for tabs in %s\n' "$TRAVIS_COMMIT_RANGE"
       ! git diff --name-only --diff-filter=ACMR "$TRAVIS_COMMIT_RANGE" | xargs grep $'\t'
     fi
-  - ( cd maud_htmlescape && cargo test --all-features )
-  - if command -v cargo-clippy > /dev/null; then ( cd maud_htmlescape && cargo clippy -- -D warnings ); fi
-  - ( cd maud && cargo test --all-features )
-  - if command -v cargo-clippy > /dev/null; then ( cd maud && cargo clippy -- -D warnings ); fi
-  - ( cd maud_macros && cargo test --all-features )
-  - if command -v cargo-clippy > /dev/null; then ( cd maud_macros && cargo clippy -- -D warnings ); fi
-  - ( cd maud_extras && cargo test --all-features )
-  - if command -v cargo-clippy > /dev/null; then ( cd maud_extras && cargo clippy -- -D warnings ); fi
+  - cargo test --all --all-features
+  - |
+    if command -v cargo-clippy > /dev/null; then
+      CLIPPY_STATUS=0
+      for package in maud_htmlescape maud_macros maud maud_extras; do
+        cargo clippy --manifest-path $package/Cargo.toml -- -D warnings || CLIPPY_STATUS=$?
+      done
+      (exit $CLIPPY_STATUS)
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ script:
   - ( cd maud && cargo test --all-features )
   - if command -v cargo-clippy > /dev/null; then ( cd maud && cargo clippy -- -D warnings ); fi
   - ( cd maud_macros && cargo test --all-features )
-  # Silence `collapsible_if` warnings for now -- see https://github.com/lfairy/maud/issues/93
-  - if command -v cargo-clippy > /dev/null; then ( cd maud_macros && cargo clippy -- -D warnings -A collapsible_if ); fi
+  - if command -v cargo-clippy > /dev/null; then ( cd maud_macros && cargo clippy -- -D warnings ); fi
   - ( cd maud_extras && cargo test --all-features )
   - if command -v cargo-clippy > /dev/null; then ( cd maud_extras && cargo clippy -- -D warnings ); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ script:
       printf 'Checking for tabs in %s\n' "$TRAVIS_COMMIT_RANGE"
       ! git diff --name-only --diff-filter=ACMR "$TRAVIS_COMMIT_RANGE" | xargs grep $'\t'
     fi
+  - ( cd maud_htmlescape && cargo test --all-features )
+  - if command -v cargo-clippy > /dev/null; then ( cd maud_htmlescape && cargo clippy -- -D warnings ); fi
   - ( cd maud && cargo test --all-features )
   - if command -v cargo-clippy > /dev/null; then ( cd maud && cargo clippy -- -D warnings ); fi
   - ( cd maud_macros && cargo test --all-features )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
-    "maud",
+    "maud_htmlescape",
     "maud_macros",
+    "maud",
     "maud_extras",
 ]

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -13,6 +13,7 @@ description = "Compile-time HTML templates."
 categories = ["template-engine"]
 
 [dependencies]
+maud_macros = { version = "0.16.3", path = "../maud_macros" }
 iron = { version = "0.5.1", optional = true }
 rocket = { version = "0.3", optional = true }
 

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -13,6 +13,7 @@ description = "Compile-time HTML templates."
 categories = ["template-engine"]
 
 [dependencies]
+maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 maud_macros = { version = "0.16.3", path = "../maud_macros" }
 iron = { version = "0.5.1", optional = true }
 rocket = { version = "0.3", optional = true }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(proc_macro)]
 #![feature(specialization)]
 
 //! A macro for writing HTML templates.
@@ -12,7 +13,11 @@
 #[cfg(feature = "iron")] extern crate iron;
 #[cfg(feature = "rocket")] extern crate rocket;
 
+extern crate maud_macros;
+
 use std::fmt::{self, Write};
+
+pub use maud_macros::{html, html_debug};
 
 /// Represents a type that can be rendered as HTML.
 ///

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -13,6 +13,7 @@
 #[cfg(feature = "iron")] extern crate iron;
 #[cfg(feature = "rocket")] extern crate rocket;
 
+extern crate maud_htmlescape;
 extern crate maud_macros;
 
 use std::fmt::{self, Write};
@@ -121,52 +122,7 @@ impl<T: AsRef<str> + Into<String>> Into<String> for PreEscaped<T> {
     }
 }
 
-/// An adapter that escapes HTML special characters.
-///
-/// The following characters are escaped:
-///
-/// * `&` is escaped as `&amp;`
-/// * `<` is escaped as `&lt;`
-/// * `>` is escaped as `&gt;`
-/// * `"` is escaped as `&quot;`
-///
-/// All other characters are passed through unchanged.
-///
-/// **Note:** In versions prior to 0.13, the single quote (`'`) was
-/// escaped as well.
-///
-/// # Example
-///
-/// ```
-/// # use maud::Escaper;
-/// use std::fmt::Write;
-/// let mut s = String::new();
-/// write!(Escaper::new(&mut s), "<script>launchMissiles()</script>").unwrap();
-/// assert_eq!(s, "&lt;script&gt;launchMissiles()&lt;/script&gt;");
-/// ```
-pub struct Escaper<'a>(&'a mut String);
-
-impl<'a> Escaper<'a> {
-    /// Creates an `Escaper` from a `String`.
-    pub fn new(buffer: &'a mut String) -> Escaper<'a> {
-        Escaper(buffer)
-    }
-}
-
-impl<'a> fmt::Write for Escaper<'a> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        for b in s.bytes() {
-            match b {
-                b'&' => self.0.push_str("&amp;"),
-                b'<' => self.0.push_str("&lt;"),
-                b'>' => self.0.push_str("&gt;"),
-                b'"' => self.0.push_str("&quot;"),
-                _ => unsafe { self.0.as_mut_vec().push(b) },
-            }
-        }
-        Ok(())
-    }
-}
+pub use maud_htmlescape::Escaper;
 
 /// The literal string `<!DOCTYPE html>`.
 ///

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -1,9 +1,8 @@
-#![feature(plugin)]
-#![plugin(maud_macros)]
+#![feature(proc_macro)]
 
 extern crate maud;
 
-use maud::Markup;
+use maud::{Markup, html};
 
 #[test]
 fn literals() {

--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -1,7 +1,8 @@
-#![feature(conservative_impl_trait, plugin)]
-#![plugin(maud_macros)]
+#![feature(conservative_impl_trait, proc_macro)]
 
 extern crate maud;
+
+use maud::html;
 
 #[test]
 fn if_expr() {

--- a/maud/tests/misc.rs
+++ b/maud/tests/misc.rs
@@ -1,7 +1,8 @@
-#![feature(plugin)]
-#![plugin(maud_macros)]
+#![feature(proc_macro)]
 
 extern crate maud;
+
+use maud::html;
 
 #[test]
 fn issue_13() {

--- a/maud/tests/splices.rs
+++ b/maud/tests/splices.rs
@@ -1,7 +1,8 @@
-#![feature(plugin)]
-#![plugin(maud_macros)]
+#![feature(proc_macro)]
 
 extern crate maud;
+
+use maud::html;
 
 #[test]
 fn literals() {

--- a/maud_extras/Cargo.toml
+++ b/maud_extras/Cargo.toml
@@ -10,7 +10,6 @@ description = "Extra bits and pieces for use in Maud templates."
 
 [dependencies]
 maud = { path = "../maud", features = ["iron"] }
-maud_macros = { path = "../maud_macros" }
 
 [lib]
 path = "lib.rs"

--- a/maud_extras/lib.rs
+++ b/maud_extras/lib.rs
@@ -1,19 +1,18 @@
-#![feature(plugin)]
-#![plugin(maud_macros)]
+#![feature(proc_macro)]
 
 extern crate maud;
 
-use maud::{Markup, Render};
+use maud::{Markup, Render, html};
 
 /// Links to an external stylesheet.
 ///
 /// # Example
 ///
 /// ```rust
-/// # #![feature(plugin)]
-/// # #![plugin(maud_macros)]
+/// # #![feature(proc_macro)]
 /// # extern crate maud;
 /// # extern crate maud_extras;
+/// # use maud::html;
 /// # use maud_extras::*;
 /// # fn main() {
 /// let markup = html! { (Css("styles.css")) };
@@ -36,10 +35,10 @@ impl<T: AsRef<str>> Render for Css<T> {
 /// # Example
 ///
 /// ```rust
-/// # #![feature(plugin)]
-/// # #![plugin(maud_macros)]
+/// # #![feature(proc_macro)]
 /// # extern crate maud;
 /// # extern crate maud_extras;
+/// # use maud::html;
 /// # use maud_extras::*;
 /// # fn main() {
 /// let markup = html! { (Js("app.js")) };
@@ -62,10 +61,10 @@ impl<T: AsRef<str>> Render for Js<T> {
 /// # Example
 ///
 /// ```rust
-/// # #![feature(plugin)]
-/// # #![plugin(maud_macros)]
+/// # #![feature(proc_macro)]
 /// # extern crate maud;
 /// # extern crate maud_extras;
+/// # use maud::html;
 /// # use maud_extras::*;
 /// # fn main() {
 /// let markup = html! { (Meta("description", "test description")) };
@@ -88,10 +87,10 @@ impl<T: AsRef<str>, U: AsRef<str>> Render for Meta<T, U> {
 /// # Example
 ///
 /// ```rust
-/// # #![feature(plugin)]
-/// # #![plugin(maud_macros)]
+/// # #![feature(proc_macro)]
 /// # extern crate maud;
 /// # extern crate maud_extras;
+/// # use maud::html;
 /// # use maud_extras::*;
 /// # fn main() {
 /// let markup = html! { (Title("Maud")) };
@@ -114,10 +113,10 @@ impl<T: AsRef<str>> Render for Title<T> {
 /// # Example
 ///
 /// ```rust
-/// # #![feature(plugin)]
-/// # #![plugin(maud_macros)]
+/// # #![feature(proc_macro)]
 /// # extern crate maud;
 /// # extern crate maud_extras;
+/// # use maud::html;
 /// # use maud_extras::*;
 /// # fn main() {
 /// let markup = html! { (Charset("utf-8")) };
@@ -140,10 +139,10 @@ impl<T: AsRef<str>> Render for Charset<T> {
 /// # Example
 ///
 /// ```rust
-/// # #![feature(plugin)]
-/// # #![plugin(maud_macros)]
+/// # #![feature(proc_macro)]
 /// # extern crate maud;
 /// # extern crate maud_extras;
+/// # use maud::html;
 /// # use maud_extras::*;
 /// # fn main() {
 /// let markup = html! { (MetaProperty("og:description", "test description")) };

--- a/maud_htmlescape/Cargo.toml
+++ b/maud_htmlescape/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+
+name = "maud_htmlescape"
+# When releasing a new version, please update html_root_url in lib.rs
+version = "0.17.0"
+authors = ["Chris Wong <lambda.fairy@gmail.com>"]
+
+license = "MIT/Apache-2.0"
+documentation = "https://docs.rs/maud_htmlescape/"
+homepage = "https://maud.lambda.xyz/"
+repository = "https://github.com/lfairy/maud"
+description = "Internal support code used by Maud."
+
+[lib]
+path = "lib.rs"

--- a/maud_htmlescape/lib.rs
+++ b/maud_htmlescape/lib.rs
@@ -1,0 +1,68 @@
+//! Internal support code used by the [Maud] template engine.
+//!
+//! You should not need to depend on this crate directly.
+//!
+//! [Maud]: https://maud.lambda.xyz
+
+#![doc(html_root_url = "https://docs.rs/maud_htmlescape/0.17.0")]
+
+use std::fmt;
+
+/// An adapter that escapes HTML special characters.
+///
+/// The following characters are escaped:
+///
+/// * `&` is escaped as `&amp;`
+/// * `<` is escaped as `&lt;`
+/// * `>` is escaped as `&gt;`
+/// * `"` is escaped as `&quot;`
+///
+/// All other characters are passed through unchanged.
+///
+/// **Note:** In versions prior to 0.13, the single quote (`'`) was
+/// escaped as well.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use std::fmt::Write;
+/// let mut s = String::new();
+/// write!(Escaper::new(&mut s), "<script>launchMissiles()</script>").unwrap();
+/// assert_eq!(s, "&lt;script&gt;launchMissiles()&lt;/script&gt;");
+/// ```
+pub struct Escaper<'a>(&'a mut String);
+
+impl<'a> Escaper<'a> {
+    /// Creates an `Escaper` from a `String`.
+    pub fn new(buffer: &'a mut String) -> Escaper<'a> {
+        Escaper(buffer)
+    }
+}
+
+impl<'a> fmt::Write for Escaper<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for b in s.bytes() {
+            match b {
+                b'&' => self.0.push_str("&amp;"),
+                b'<' => self.0.push_str("&lt;"),
+                b'>' => self.0.push_str("&gt;"),
+                b'"' => self.0.push_str("&quot;"),
+                _ => unsafe { self.0.as_mut_vec().push(b) },
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fmt::Write;
+    use Escaper;
+
+    #[test]
+    fn it_works() {
+        let mut s = String::new();
+        write!(Escaper::new(&mut s), "<script>launchMissiles()</script>").unwrap();
+        assert_eq!(s, "&lt;script&gt;launchMissiles()&lt;/script&gt;");
+    }
+}

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -13,7 +13,7 @@ description = "Compile-time HTML templates."
 
 [dependencies]
 if_chain = "0.1"
-literalext = { git = "https://github.com/mystor/literalext.git", default-features = false, features = ["proc-macro"] }
+literalext = { version = "0.1", default-features = false, features = ["proc-macro"] }
 
 [lib]
 name = "maud_macros"

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/lfairy/maud"
 description = "Compile-time HTML templates."
 
 [dependencies]
-if_chain = "0.1"
 literalext = { version = "0.1", default-features = false, features = ["proc-macro"] }
 
 [lib]

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -13,11 +13,11 @@ description = "Compile-time HTML templates."
 
 [dependencies]
 if_chain = "0.1"
-maud = { path = "../maud", version = "0.16.0" }
+literalext = { git = "https://github.com/mystor/literalext.git", default-features = false, features = ["proc-macro"] }
 
 [lib]
 name = "maud_macros"
-plugin = true
+proc-macro = true
 
 [badges]
 travis-ci = { repository = "lfairy/maud" }

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -13,6 +13,7 @@ description = "Compile-time HTML templates."
 
 [dependencies]
 literalext = { version = "0.1", default-features = false, features = ["proc-macro"] }
+maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 
 [lib]
 name = "maud_macros"

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -3,8 +3,6 @@
 
 #![doc(html_root_url = "https://docs.rs/maud_macros/0.16.3")]
 
-#[macro_use]
-extern crate if_chain;
 extern crate literalext;
 extern crate proc_macro;
 

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -1,53 +1,46 @@
-#![crate_type = "dylib"]
-#![feature(plugin_registrar, quote)]
-#![feature(slice_patterns)]
-#![feature(rustc_private)]
+#![feature(proc_macro)]
 #![recursion_limit = "1000"]  // if_chain
 
 #![doc(html_root_url = "https://docs.rs/maud_macros/0.16.3")]
 
 #[macro_use]
 extern crate if_chain;
-#[macro_use]
-extern crate rustc;
-extern crate rustc_plugin;
-extern crate syntax;
-extern crate maud;
+extern crate literalext;
+extern crate proc_macro;
 
-use rustc_plugin::Registry;
-use syntax::codemap::Span;
-use syntax::ext::base::{DummyResult, ExtCtxt, MacEager, MacResult};
-use syntax::print::pprust;
-use syntax::tokenstream::TokenTree;
-
-mod lints;
+// TODO move lints into their own `maud_lints` crate
+// mod lints;
 mod parse;
 mod render;
 
-type ParseResult<T> = Result<T, ()>;
+use proc_macro::TokenStream;
 
-fn expand_html<'cx>(cx: &'cx mut ExtCtxt, sp: Span, args: &[TokenTree]) -> Box<MacResult + 'cx> {
-    match parse::parse(cx, sp, args) {
-        Ok(expr) => MacEager::expr(quote_expr!(cx, $expr)),
-        Err(..) => DummyResult::expr(sp),
+type ParseResult<T> = Result<T, String>;
+
+#[proc_macro]
+pub fn html(args: TokenStream) -> TokenStream {
+    match parse::parse(args) {
+        Ok(expr) => expr,
+        Err(e) => panic!(e),
     }
 }
 
-fn expand_html_debug<'cx>(cx: &'cx mut ExtCtxt, sp: Span, args: &[TokenTree]) -> Box<MacResult + 'cx> {
-    match parse::parse(cx, sp, args) {
+#[proc_macro]
+pub fn html_debug(args: TokenStream) -> TokenStream {
+    match parse::parse(args) {
         Ok(expr) => {
-            let expr = quote_expr!(cx, $expr);
-            cx.span_warn(sp, &format!("expansion:\n{}",
-                                      pprust::expr_to_string(&expr)));
-            MacEager::expr(expr)
+            println!("expansion:\n{}", expr);
+            expr
         },
-        Err(..) => DummyResult::expr(sp),
+        Err(e) => panic!(e),
     }
 }
 
+/*
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_macro("html", expand_html);
     reg.register_macro("html_debug", expand_html_debug);
     lints::register_lints(reg);
 }
+*/

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -4,6 +4,7 @@
 #![doc(html_root_url = "https://docs.rs/maud_macros/0.16.3")]
 
 extern crate literalext;
+extern crate maud_htmlescape;
 extern crate proc_macro;
 
 // TODO move lints into their own `maud_lints` crate

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -168,17 +168,15 @@ impl Parser {
             }
         }
         let mut expr = Vec::new();
-        let body;
-        loop {
+        let body = loop {
             match self.next() {
                 Some(TokenTree { kind: TokenNode::Group(Delimiter::Brace, block), .. }) => {
-                    body = self.block(block, render)?;
-                    break;
+                    break self.block(block, render)?;
                 },
                 Some(token) => expr.push(token),
                 None => return self.error("unexpected end of @let expression"),
             }
-        }
+        };
         render.emit_let(pat.into_iter().collect(), expr.into_iter().collect(), body);
         Ok(())
     }
@@ -343,6 +341,7 @@ impl Parser {
     }
 }
 
+// TODO use rust-lang/rust#43280 instead
 struct Lookahead<T> {
     buffer: Vec<T>,
     index: usize,

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -1,4 +1,14 @@
-use proc_macro::{Delimiter, Literal, Spacing, TokenNode, TokenStream, TokenTree, TokenTreeIter, quote};
+use proc_macro::{
+    Delimiter,
+    Literal,
+    Spacing,
+    Span,
+    TokenNode,
+    TokenStream,
+    TokenTree,
+    TokenTreeIter,
+};
+use std::iter;
 use std::mem;
 
 use literalext::LiteralExt;
@@ -292,7 +302,7 @@ impl Parser {
                 TokenTree {
                     kind: TokenNode::Group(Delimiter::Brace, body),
                     span,
-                }.into()
+                }
             },
             // $pat => $expr
             Some(first_token) => {
@@ -310,11 +320,14 @@ impl Parser {
                 // The generated code may have multiple statements, unlike the
                 // original expression. So wrap the whole thing in a block just
                 // in case.
-                quote!({ $body })
+                TokenTree {
+                    kind: TokenNode::Group(Delimiter::Brace, body),
+                    span: Span::default(),
+                }
             },
             None => return self.error("unexpected end of @match arm"),
         };
-        Ok(Some(pat.into_iter().chain(body.into_iter()).collect()))
+        Ok(Some(pat.into_iter().chain(iter::once(body)).collect()))
     }
 
     /// Parses and renders a `@let` expression.

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -7,14 +7,14 @@ use super::render::Renderer;
 use super::ParseResult;
 
 pub fn parse(input: TokenStream) -> ParseResult<TokenStream> {
-    let mut render = Renderer::new();
-    let _ = Parser {
-        in_attr: false,
-        input: input.clone().into_iter(),
-    }.markups(&mut render)?;
     // Heuristic: the size of the resulting markup tends to correlate with the
     // code size of the template itself
     let size_hint = input.to_string().len();
+    let mut render = Renderer::new();
+    Parser {
+        in_attr: false,
+        input: input.into_iter(),
+    }.markups(&mut render)?;
     Ok(render.into_expr(size_hint))
 }
 
@@ -24,11 +24,15 @@ struct Parser {
     input: TokenTreeIter,
 }
 
-impl Parser {
+impl Iterator for Parser {
+    type Item = TokenTree;
+
     fn next(&mut self) -> Option<TokenTree> {
         self.input.next()
     }
+}
 
+impl Parser {
     fn peek(&mut self) -> Option<TokenTree> {
         self.clone().next()
     }

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -188,7 +188,18 @@ impl Parser {
     ///
     /// The leading `@while` should already be consumed.
     fn while_expr(&mut self, render: &mut Renderer) -> ParseResult<()> {
-        self.error("unimplemented")
+        let mut cond = Vec::new();
+        let body = loop {
+            match self.next() {
+                Some(TokenTree { kind: TokenNode::Group(Delimiter::Brace, block), .. }) => {
+                    break self.block(block, render)?;
+                },
+                Some(token) => cond.push(token),
+                None => return self.error("unexpected end of @while expression"),
+            }
+        };
+        render.emit_while(cond.into_iter().collect(), body);
+        Ok(())
     }
 
     /// Parses and renders a `@for` expression.

--- a/maud_macros/src/render.rs
+++ b/maud_macros/src/render.rs
@@ -1,6 +1,7 @@
 use proc_macro::{Literal, Term, TokenNode, TokenStream};
 use proc_macro::quote;
-use std::fmt;
+
+use maud_htmlescape::Escaper;
 
 pub struct Renderer {
     output: TokenNode,
@@ -165,29 +166,4 @@ fn html_escape(s: &str) -> String {
     let mut buffer = String::new();
     Escaper::new(&mut buffer).write_str(s).unwrap();
     buffer
-}
-
-// TODO move this into a common `maud_htmlescape` crate
-struct Escaper<'a>(&'a mut String);
-
-impl<'a> Escaper<'a> {
-    /// Creates an `Escaper` from a `String`.
-    pub fn new(buffer: &'a mut String) -> Escaper<'a> {
-        Escaper(buffer)
-    }
-}
-
-impl<'a> fmt::Write for Escaper<'a> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        for b in s.bytes() {
-            match b {
-                b'&' => self.0.push_str("&amp;"),
-                b'<' => self.0.push_str("&lt;"),
-                b'>' => self.0.push_str("&gt;"),
-                b'"' => self.0.push_str("&quot;"),
-                _ => unsafe { self.0.as_mut_vec().push(b) },
-            }
-        }
-        Ok(())
-    }
 }


### PR DESCRIPTION
This changes how Maud is imported.

Users will need to change their code from this:

```rust
// Maud 0.16
#![feature(plugin)]
#![plugin(maud_macros)]
extern crate maud;
```

to this:

```rust
// Maud 0.17
#![feature(proc_macro)]
extern crate maud;
use maud::html;
```

Note the lack of `#![plugin]` or `#[macro_use]` attributes -- the new proc macro system allows for importing macros in the same way as any other item.

Closes #92