### PR TITLE
Allow terminating void elements with semicolons (;)

### DIFF
--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -54,14 +54,20 @@ fn nesting_elements() {
 
 #[test]
 fn empty_elements() {
-    let s = html!("pinkie" br/ "pie").into_string();
+    let s = html!("pinkie" br; "pie").into_string();
+    assert_eq!(s, "pinkie<br>pie");
+}
+
+#[test]
+fn empty_elements_slash() {
+    let s = html!("pinkie" br / "pie").into_string();
     assert_eq!(s, "pinkie<br>pie");
 }
 
 #[test]
 fn simple_attributes() {
     let s = html! {
-        link rel="stylesheet" href="styles.css"/
+        link rel="stylesheet" href="styles.css";
         section id="midriff" {
             p class="hotpink" "Hello!"
         }
@@ -73,7 +79,7 @@ fn simple_attributes() {
 
 #[test]
 fn empty_attributes() {
-    let s = html!(div readonly? input type="checkbox" checked? /).into_string();
+    let s = html!(div readonly? input type="checkbox" checked?;).into_string();
     assert_eq!(s, r#"<div readonly><input type="checkbox" checked></div>"#);
 }
 
@@ -81,10 +87,10 @@ fn empty_attributes() {
 fn toggle_empty_attributes() {
     let rocks = true;
     let s = html!({
-        input checked?[true] /
-        input checked?[false] /
-        input checked?[rocks] /
-        input checked?[!rocks] /
+        input checked?[true];
+        input checked?[false];
+        input checked?[rocks];
+        input checked?[!rocks];
     }).into_string();
     assert_eq!(s, concat!(
             r#"<input checked>"#,

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -367,6 +367,7 @@ impl Parser {
         self.attrs(render)?;
         render.element_open_end();
         match self.peek() {
+            Some(TokenTree { kind: TokenNode::Op(';', _), .. }) |
             Some(TokenTree { kind: TokenNode::Op('/', _), .. }) => {
                 // Void element
                 self.advance();


### PR DESCRIPTION
When Rust and HTML syntax differ, Maud tends to side with Rust syntax. This can be seen with string literals, for example, where we use backslash escapes instead of HTML entities. Using `;` to terminate void
elements is consistent with this idea.

Moreover, this reduces confusion around the generated code. Maud does not insert an extra slash into the HTML output (as per the spec) but the syntax may imply otherwise.

This confusion may have been the cause of a [bug I found in the wild][1], where the code omitted the trailing slash on an `input` element. I suspect that this is because the author thought that a trailing slash in the Maud template would lead to one in the HTML output. Switching to semicolons would prevent this misconception.

[1]: https://github.com/anowell/quasar/pull/3