### PR TITLE
Add `Clone` and `Copy` impl to `PreEscaped` via derive

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -95,7 +95,7 @@ impl Render for str {
 }
 
 /// A wrapper that renders the inner value without escaping.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct PreEscaped<T: AsRef<str>>(pub T);
 
 impl<T: AsRef<str>> Render for PreEscaped<T> {


### PR DESCRIPTION
Fixes #100 