### PR TITLE
Enforce nightly toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This file makes `rustup` select the nightly toolchain for this project, as it
requires. See https://github.com/rust-lang-nursery/rustup.rs/tree/533f09818fff23ba55a7c60474f3798d41bdd69d#the-toolchain-file