### PR TITLE
Refactor to keep up with changes to proc_macro

### DIFF
--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -1,4 +1,3 @@
-#![feature(conservative_impl_trait)]
 #![feature(plugin)]
 #![feature(proc_macro)]
 

--- a/maud_macros/src/build.rs
+++ b/maud_macros/src/build.rs
@@ -34,15 +34,7 @@ impl Builder {
     /// Reifies the `Builder` into a raw list of statements.
     pub fn build(mut self) -> TokenStream {
         let Builder { stmts, .. } = { self.flush(); self };
-
-        // use a Group here?
-        let mut tts: Vec<TokenTree> = Vec::new();
-        for s in stmts.into_iter() {
-            let i = s.into_iter();
-            tts.extend(i);
-        }
-
-        tts.into_iter().collect()
+        stmts.into_iter().collect()
     }
 
     /// Pushes a statement, flushing the tail buffer in the process.

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(proc_macro)]
+#![feature(pattern_parentheses)]
 
 #![doc(html_root_url = "https://docs.rs/maud_macros/0.17.2")]
 
@@ -9,7 +10,7 @@ extern crate proc_macro;
 mod parse;
 mod build;
 
-use proc_macro::{Literal, Span, Term, TokenNode, TokenStream, TokenTree};
+use proc_macro::{Span, Term, TokenStream, TokenTree};
 use proc_macro::quote;
 
 type ParseResult<T> = Result<T, String>;
@@ -27,21 +28,21 @@ pub fn html_debug(input: TokenStream) -> TokenStream {
 }
 
 fn expand(input: TokenStream) -> TokenStream {
-    let output_ident = TokenTree {
-        kind: TokenNode::Term(Term::intern("__maud_output")),
-        span: Span::def_site(),
-    };
+ 
+    let output_ident = TokenTree::Term(Term::new("__maud_output", Span::def_site()));
     // Heuristic: the size of the resulting markup tends to correlate with the
     // code size of the template itself
-    let size_hint = input.to_string().len();
-    let size_hint = TokenNode::Literal(Literal::u64(size_hint as u64));
+    //
+    // NOTE: can't get this to compile inside quote!
+    //let size_hint = Literal::u64_unsuffixed(size_hint as u64);
     let stmts = match parse::parse(input, output_ident.clone()) {
         Ok(stmts) => stmts,
         Err(e) => panic!(e),
     };
     quote!({
         extern crate maud;
-        let mut $output_ident = String::with_capacity($size_hint as usize);
+        //let mut $output_ident = String::with_capacity($size_hint as usize);
+        let mut $output_ident = String::new();
         $stmts
         maud::PreEscaped($output_ident)
     })

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -10,6 +10,7 @@ use proc_macro::{
 };
 
 use proc_macro::token_stream;
+use std::iter;
 use std::mem;
 
 use literalext::LiteralExt;
@@ -302,14 +303,14 @@ impl Parser {
     }
 
     fn match_arms(&mut self) -> ParseResult<TokenStream> {
-        let mut arms: Vec<TokenTree> = Vec::new();
+        let mut arms = Vec::new();
         while let Some(arm) = self.match_arm()? {
-            arms.extend(arm);
+            arms.push(arm);
         }
         Ok(arms.into_iter().collect())
     }
 
-    fn match_arm(&mut self) -> ParseResult<Option<Vec<TokenTree>>> {
+    fn match_arm(&mut self) -> ParseResult<Option<TokenStream>> {
         let mut pat: Vec<TokenTree> = Vec::new();
         loop {
             match self.peek2() {
@@ -364,8 +365,7 @@ impl Parser {
             },
             None => return self.error("unexpected end of @match arm"),
         };
-        pat.push(body);
-        Ok(Some(pat))
+        Ok(Some(pat.into_iter().chain(iter::once(body)).collect()))
     }
 
     /// Parses and renders a `@let` expression.


### PR DESCRIPTION
Instead of a `kind` field containting a `TokenNode` variant, a
TokenTree is now an enum with variants of different types (Literal, Op,
Term, etc). Note that a TokenTree could be a sequence of TokenTrees if it is a
Group variant.

Other notes:

I'm unsure about the set_span call in Builder::emit_if, but I did not want to
throw away the passed in Span.

Parsing relies on destructuring references to the values associated with
TokenTree enum variants

Refs #121