### PR TITLE
Require braces around the body of an element

### DIFF
--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -51,12 +51,6 @@ fn simple_elements() {
 }
 
 #[test]
-fn nesting_elements() {
-    let s = html!(html body div p sup "butts").into_string();
-    assert_eq!(s, "<html><body><div><p><sup>butts</sup></p></div></body></html>");
-}
-
-#[test]
 fn empty_elements() {
     let s = html!("pinkie" br; "pie").into_string();
     assert_eq!(s, "pinkie<br>pie");
@@ -73,7 +67,7 @@ fn simple_attributes() {
     let s = html! {
         link rel="stylesheet" href="styles.css";
         section id="midriff" {
-            p class="hotpink" "Hello!"
+            p class="hotpink" { "Hello!" }
         }
     }.into_string();
     assert_eq!(s, concat!(
@@ -83,7 +77,7 @@ fn simple_attributes() {
 
 #[test]
 fn empty_attributes() {
-    let s = html!(div readonly? input type="checkbox" checked?;).into_string();
+    let s = html!(div readonly? { input type="checkbox" checked?; }).into_string();
     assert_eq!(s, r#"<div readonly><input type="checkbox" checked></div>"#);
 }
 
@@ -112,7 +106,7 @@ fn toggle_empty_attributes_braces() {
 
 #[test]
 fn colons_in_names() {
-    let s = html!(pon-pon:controls-alpha a on:click="yay()" "Yay!").into_string();
+    let s = html!(pon-pon:controls-alpha { a on:click="yay()" { "Yay!" } }).into_string();
     assert_eq!(s, concat!(
             r#"<pon-pon:controls-alpha>"#,
             r#"<a on:click="yay()">Yay!</a>"#,
@@ -151,14 +145,14 @@ fn classes_shorthand() {
 
 #[test]
 fn hyphens_in_class_names() {
-    let s = html!(p.rocks-these.are--my--rocks "yes").into_string();
+    let s = html!(p.rocks-these.are--my--rocks { "yes" }).into_string();
     assert_eq!(s, r#"<p class="rocks-these are--my--rocks">yes</p>"#);
 }
 
 #[test]
 fn toggle_classes() {
     fn test(is_cupcake: bool, is_muffin: bool) -> Markup {
-        html!(p.cupcake[is_cupcake].muffin[is_muffin] "Testing!")
+        html!(p.cupcake[is_cupcake].muffin[is_muffin] { "Testing!" })
     }
     assert_eq!(test(true, true).into_string(), r#"<p class="cupcake muffin">Testing!</p>"#);
     assert_eq!(test(false, true).into_string(), r#"<p class=" muffin">Testing!</p>"#);
@@ -169,14 +163,14 @@ fn toggle_classes() {
 #[test]
 fn toggle_classes_braces() {
     struct Maud { rocks: bool }
-    let s = html!(p.rocks[Maud { rocks: true }.rocks] "Awesome!").into_string();
+    let s = html!(p.rocks[Maud { rocks: true }.rocks] { "Awesome!" }).into_string();
     assert_eq!(s, r#"<p class="rocks">Awesome!</p>"#);
 }
 
 #[test]
 fn mixed_classes() {
     fn test(is_muffin: bool) -> Markup {
-        html!(p.cupcake.muffin[is_muffin].lamington "Testing!")
+        html!(p.cupcake.muffin[is_muffin].lamington { "Testing!" })
     }
     assert_eq!(test(true).into_string(), r#"<p class="cupcake lamington muffin">Testing!</p>"#);
     assert_eq!(test(false).into_string(), r#"<p class="cupcake lamington">Testing!</p>"#);

--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -44,8 +44,10 @@ fn if_let() {
 fn while_expr() {
     let mut numbers = (0..3).into_iter().peekable();
     let s = html! {
-        ul @while numbers.peek().is_some() {
-            li (numbers.next().unwrap())
+        ul {
+            @while numbers.peek().is_some() {
+                li { (numbers.next().unwrap()) }
+            }
         }
     }.into_string();
     assert_eq!(s, "<ul><li>0</li><li>1</li><li>2</li></ul>");
@@ -56,8 +58,10 @@ fn while_let_expr() {
     let mut numbers = (0..3).into_iter();
     #[cfg_attr(feature = "cargo-clippy", allow(while_let_on_iterator))]
     let s = html! {
-        ul @while let Some(n) = numbers.next() {
-            li (n)
+        ul {
+            @while let Some(n) = numbers.next() {
+                li { (n) }
+            }
         }
     }.into_string();
     assert_eq!(s, "<ul><li>0</li><li>1</li><li>2</li></ul>");
@@ -67,8 +71,10 @@ fn while_let_expr() {
 fn for_expr() {
     let ponies = ["Apple Bloom", "Scootaloo", "Sweetie Belle"];
     let s = html! {
-        ul @for pony in &ponies {
-            li (pony)
+        ul {
+            @for pony in &ponies {
+                li { (pony) }
+            }
         }
     }.into_string();
     assert_eq!(s, concat!(
@@ -85,7 +91,7 @@ fn match_expr() {
         let s = html! {
             @match input {
                 Some(value) => {
-                    div (value)
+                    div { (value) }
                 },
                 None => {
                     "oh noes"
@@ -102,7 +108,7 @@ fn match_expr_without_delims() {
         let s = html! {
             @match input {
                 Some(value) => (value),
-                None => span "oh noes",
+                None => span { "oh noes" },
             }
         }.into_string();
         assert_eq!(s, output);

--- a/maud_extras/lib.rs
+++ b/maud_extras/lib.rs
@@ -112,7 +112,7 @@ pub struct Title<T: AsRef<str>>(pub T);
 impl<T: AsRef<str>> Render for Title<T> {
     fn render(&self) -> Markup {
         html! {
-            title (self.0.as_ref())
+            title { (self.0.as_ref()) }
         }
     }
 }

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -12,6 +12,7 @@ pub enum Markup {
     },
     Splice {
         expr: TokenStream,
+        outer_span: Span,
     },
     Element {
         name: TokenStream,

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -16,7 +16,7 @@ pub enum Markup {
     Element {
         name: TokenStream,
         attrs: Attrs,
-        body: Option<Box<Markup>>,
+        body: ElementBody,
     },
     Let {
         tokens: TokenStream,
@@ -41,6 +41,12 @@ pub struct Attrs {
 }
 
 pub type ClassOrId = TokenStream;
+
+#[derive(Debug)]
+pub enum ElementBody {
+    Void { semi_span: Span },
+    Block { block: Block },
+}
 
 #[derive(Debug)]
 pub struct Block {

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -20,6 +20,7 @@ pub enum Markup {
         body: ElementBody,
     },
     Let {
+        at_span: Span,
         tokens: TokenStream,
     },
     Special {

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -51,7 +51,7 @@ pub enum ElementBody {
 #[derive(Debug)]
 pub struct Block {
     pub markups: Vec<Markup>,
-    pub span: Span,
+    pub outer_span: Span,
 }
 
 #[derive(Debug)]

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -96,15 +96,15 @@ impl Generator {
         &self,
         name: TokenStream,
         attrs: Attrs,
-        body: Option<Box<Markup>>,
+        body: ElementBody,
         build: &mut Builder,
     ) {
         build.push_str("<");
         self.name(name.clone(), build);
         self.attrs(attrs, build);
         build.push_str(">");
-        if let Some(body) = body {
-            self.markup(*body, build);
+        if let ElementBody::Block { block } = body {
+            self.markups(block.markups, build);
             build.push_str("</");
             self.name(name, build);
             build.push_str(">");

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -50,7 +50,7 @@ impl Generator {
             Markup::Symbol { symbol } => self.name(symbol, build),
             Markup::Splice { expr, .. } => build.push_tokens(self.splice(expr)),
             Markup::Element { name, attrs, body } => self.element(name, attrs, body, build),
-            Markup::Let { tokens } => build.push_tokens(tokens),
+            Markup::Let { tokens, .. } => build.push_tokens(tokens),
             Markup::Special { segments } => {
                 for segment in segments {
                     build.push_tokens(self.special(segment));

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -48,7 +48,7 @@ impl Generator {
             },
             Markup::Literal { content, .. } => build.push_escaped(&content),
             Markup::Symbol { symbol } => self.name(symbol, build),
-            Markup::Splice { expr } => build.push_tokens(self.splice(expr)),
+            Markup::Splice { expr, .. } => build.push_tokens(self.splice(expr)),
             Markup::Element { name, attrs, body } => self.element(name, attrs, body, build),
             Markup::Let { tokens } => build.push_tokens(tokens),
             Markup::Special { segments } => {

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -224,16 +224,6 @@ fn desugar_toggler(Toggler { mut cond, cond_span }: Toggler) -> TokenStream {
     quote!(if $cond)
 }
 
-fn span_tokens<I: IntoIterator<Item=TokenTree>>(tokens: I) -> Span {
-    tokens
-        .into_iter()
-        .fold(None, |span: Option<Span>, token| Some(match span {
-            None => token.span(),
-            Some(span) => span.join(token.span()).unwrap_or(span),
-        }))
-        .unwrap_or_else(Span::def_site)
-}
-
 ////////////////////////////////////////////////////////
 
 struct Builder {

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -92,7 +92,7 @@ impl Parser {
                 )) if punct.as_char() == '@' && ident.to_string() == "let" => {
                     self.advance2();
                     let keyword = TokenTree::Ident(ident.clone());
-                    result.push(self.let_expr(keyword)?);
+                    result.push(self.let_expr(punct.span(), keyword)?);
                 },
                 _ => result.push(self.markup()?),
             }
@@ -371,7 +371,7 @@ impl Parser {
     /// Parses a `@let` expression.
     ///
     /// The leading `@let` should already be consumed.
-    fn let_expr(&mut self, keyword: TokenTree) -> ParseResult<ast::Markup> {
+    fn let_expr(&mut self, at_span: Span, keyword: TokenTree) -> ParseResult<ast::Markup> {
         let mut tokens = vec![keyword];
         loop {
             match self.next() {
@@ -401,7 +401,7 @@ impl Parser {
                 None => return self.error("unexpected end of @let expression"),
             }
         }
-        Ok(ast::Markup::Let { tokens: tokens.into_iter().collect() })
+        Ok(ast::Markup::Let { at_span, tokens: tokens.into_iter().collect() })
     }
 
     /// Parses an element node.

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -417,9 +417,19 @@ impl Parser {
             if punct.as_char() == ';' || punct.as_char() == '/' => {
                 // Void element
                 self.advance();
-                None
+                ast::ElementBody::Void { semi_span: punct.span() }
             },
-            _ => Some(Box::new(self.markup()?)),
+            _ => {
+                match self.markup()? {
+                    ast::Markup::Block(block) => ast::ElementBody::Block { block },
+                    markup => ast::ElementBody::Block {
+                        block: ast::Block {
+                            markups: vec![markup],
+                            span: Span::call_site(),
+                        },
+                    },
+                }
+            },
         };
         Ok(ast::Markup::Element { name, attrs, body })
     }

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -425,7 +425,7 @@ impl Parser {
                     markup => ast::ElementBody::Block {
                         block: ast::Block {
                             markups: vec![markup],
-                            span: Span::call_site(),
+                            outer_span: Span::call_site(),
                         },
                     },
                 }
@@ -548,8 +548,8 @@ impl Parser {
     }
 
     /// Parses the given token stream as a Maud expression.
-    fn block(&mut self, body: TokenStream, span: Span) -> ParseResult<ast::Block> {
+    fn block(&mut self, body: TokenStream, outer_span: Span) -> ParseResult<ast::Block> {
         let markups = self.with_input(body).markups()?;
-        Ok(ast::Block { markups, span })
+        Ok(ast::Block { markups, outer_span })
     }
 }

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -422,11 +422,18 @@ impl Parser {
             _ => {
                 match self.markup()? {
                     ast::Markup::Block(block) => ast::ElementBody::Block { block },
-                    markup => ast::ElementBody::Block {
-                        block: ast::Block {
-                            markups: vec![markup],
-                            outer_span: Span::call_site(),
-                        },
+                    markup => {
+                        let markup_span = markup.span();
+                        markup_span
+                            .error("element body must be wrapped in braces")
+                            .help("see https://github.com/lfairy/maud/pull/137 for details")
+                            .emit();
+                        ast::ElementBody::Block {
+                            block: ast::Block {
+                                markups: vec![markup],
+                                outer_span: markup_span,
+                            },
+                        }
                     },
                 }
             },

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -143,7 +143,7 @@ impl Parser {
             // Splice
             TokenTree::Group(ref group) if group.delimiter() == Delimiter::Parenthesis => {
                 self.advance();
-                ast::Markup::Splice { expr: group.stream() }
+                ast::Markup::Splice { expr: group.stream(), outer_span: group.span() }
             }
             // Block
             TokenTree::Group(ref group) if group.delimiter() == Delimiter::Brace => {


### PR DESCRIPTION
# Summary

Maud now requires braces around the body of an HTML element. For example, this code

```rust
html! {
    h1 a href="/" "Pinkie Pie's awesome website"
    div#main (contents)
}
```

must now be written as

```rust
html! {
    h1 {
        a href="/" { "Pinkie Pie's awesome website" }
    }
    div#main { (contents) }
}
```

This change was made to address usability issues, as well as improve visual harmony with surrounding Rust code.

# Rationale

Omitting the braces around an element body can reduce clutter. The feature is also easy to implement, and does not introduce ambiguity in the formal grammar.

However, over the last few months I have found many arguments for removing the feature:

* In #117, a user questioned why `label "Email" for="email"` didn't work. If we had required braces around the body, then it would be clear why `label { "Email" } for="email"` wouldn't parse.

* A void element (e.g. `input type="text";`) is always terminated by a semicolon. But an element with a single node in its body (e.g. `p "hello"`) does not require a semicolon. This is inconsistent with Rust syntax in general, which requires semicolons on statements unless they have return values or end with a braced block.

* The shorthand syntax also hides errors. If the user omits the trailing semicolon on a void element, then Maud will emit an extra end tag. For example, this code:

  ```rust
  html! {
      input name="cuteness" type="number"  // note missing `;`
      button "Update!"
  }
  ```

  results in the following HTML:

  ```html
  <input name="cuteness" type="number">
      <button>Update!</button>
  </input>
  ```

  It's possible for the library to detect and warn about these cases, but we should aim to avoid this situation in the first place.

# FAQ

## Do we need a deprecation period for this change?

I don't think so. Template engines tend to be direct dependencies, not transitive ones (like Serde), so it should be easy to pin an older version if you're not ready to deal with the breakage yet.

## I have another question. Should I ask it here?

Go for it! 😄