### PR TITLE
Implement streaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ before_script:
   - rustup component add clippy-preview --toolchain=nightly
 
 script:
+  - (cd maud && cargo build --features="streaming")
   - (cd maud && cargo build --features="iron")
   - (cd maud && cargo build --features="rocket")
   - (cd maud && cargo build --features="actix-web")
   - cargo test --all
+  - (cd maud && cargo test --features="streaming")
   - (cd benchmarks && cargo bench --no-run)
   - |
     CLIPPY_STATUS=0

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -21,6 +21,7 @@ rocket = { version = "0.3", optional = true }
 actix-web = { version = ">= 0.6.12, < 0.8.0", optional = true }
 
 [features]
+default = ["streaming"]
 streaming = ["futures", "maud_macros/streaming"]
 
 [badges]

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -13,6 +13,7 @@ description = "Compile-time HTML templates."
 categories = ["template-engine"]
 
 [dependencies]
+futures = "0.1"
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 maud_macros = { version = "0.19.0", path = "../maud_macros" }
 iron = { version = ">= 0.5.1, < 0.7.0", optional = true }

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -13,12 +13,15 @@ description = "Compile-time HTML templates."
 categories = ["template-engine"]
 
 [dependencies]
-futures = "0.1"
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 maud_macros = { version = "0.19.0", path = "../maud_macros" }
+futures = { version = "0.1", optional = true }
 iron = { version = ">= 0.5.1, < 0.7.0", optional = true }
 rocket = { version = "0.3", optional = true }
 actix-web = { version = ">= 0.6.12, < 0.8.0", optional = true }
+
+[features]
+streaming = ["futures", "maud_macros/streaming"]
 
 [badges]
 travis-ci = { repository = "lfairy/maud" }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -104,29 +104,29 @@ impl Render for str {
 #[cfg(feature = "streaming")]
 pub trait FutureRender {
     fn render_to(&self, stream: &mut futures::stream::FuturesOrdered<
-        Box<futures::Future<Item = String, Error = String> + Send>
+        Box<futures::Future<Item = Markup, Error = Markup> + Send>
     >);
 }
 
 #[cfg(feature = "streaming")]
 impl FutureRender for String {
     fn render_to(&self, stream: &mut futures::stream::FuturesOrdered<
-        Box<futures::Future<Item = String, Error = String> + Send>
+        Box<futures::Future<Item = Markup, Error = Markup> + Send>
     >) {
         let mut escaped = String::with_capacity(self.len());
         let _ = Escaper::new(&mut escaped).write_str(self);
-        stream.push(Box::new(futures::future::ok(escaped)));
+        stream.push(Box::new(futures::future::ok(PreEscaped(escaped))));
     }
 }
 
 #[cfg(feature = "streaming")]
 impl FutureRender for str {
     fn render_to(&self, stream: &mut futures::stream::FuturesOrdered<
-        Box<futures::Future<Item = String, Error = String> + Send>
+        Box<futures::Future<Item = Markup, Error = Markup> + Send>
     >) {
         let mut escaped = String::with_capacity(self.len());
         let _ = Escaper::new(&mut escaped).write_str(self);
-        stream.push(Box::new(futures::future::ok(escaped)));
+        stream.push(Box::new(futures::future::ok(PreEscaped(escaped))));
     }
 }
 
@@ -142,11 +142,11 @@ impl<T: AsRef<str>> Render for PreEscaped<T> {
 
 impl<T: AsRef<str>> FutureRender for PreEscaped<T> {
     fn render_to(&self, stream: &mut futures::stream::FuturesOrdered<
-        Box<futures::Future<Item = String, Error = String> + Send>
+        Box<futures::Future<Item = Markup, Error = Markup> + Send>
     >) {
         let mut escaped = String::with_capacity(self.0.as_ref().len());
         let _ = Escaper::new(&mut escaped).write_str(self.0.as_ref());
-        stream.push(Box::new(futures::future::ok(escaped)));
+        stream.push(Box::new(futures::future::ok(PreEscaped(escaped))));
     }
 }
 

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -18,7 +18,7 @@ extern crate maud_macros;
 
 use std::fmt::{self, Write};
 
-pub use maud_macros::{html, html_debug};
+pub use maud_macros::{html, html_debug, html_stream, html_stream_debug};
 
 /// Represents a type that can be rendered as HTML.
 ///

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![doc(html_root_url = "https://docs.rs/maud/0.19.0")]
 
+#[cfg(feature = "streaming")] extern crate futures;
 #[cfg(feature = "actix-web")] extern crate actix_web;
 #[cfg(feature = "iron")] extern crate iron;
 #[cfg(feature = "rocket")] extern crate rocket;
@@ -18,7 +19,10 @@ extern crate maud_macros;
 
 use std::fmt::{self, Write};
 
-pub use maud_macros::{html, html_debug, html_stream, html_stream_debug};
+pub use maud_macros::{html, html_debug};
+
+#[cfg(feature = "streaming")]
+pub use maud_macros::{html_stream, html_stream_debug};
 
 /// Represents a type that can be rendered as HTML.
 ///

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -202,6 +202,17 @@ fn toggle_classes_braces() {
     assert_eq!(s, r#"<p class="rocks">Awesome!</p>"#);
 }
 
+#[cfg(feature = "streaming")]
+#[test]
+fn toggle_classes_braces_stream() {
+    struct Maud { rocks: bool }
+    let mut s = html_stream_debug!(p.rocks[Maud { rocks: true }.rocks] { "Awesome!" }).wait();
+    assert_eq!(s.next(), Some(Ok(r#"<p class=""#)));
+    assert_eq!(s.next(), Some(Ok(r#"rocks"#)));
+    assert_eq!(s.next(), Some(Ok(r#"">Awesome!</p>"#)));
+    assert_eq!(s.next(), None);
+}
+
 #[test]
 fn toggle_classes_string() {
     let is_cupcake = true;

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -8,7 +8,7 @@ extern crate maud;
 use futures::Stream;
 use maud::{Markup, html};
 #[cfg(feature = "streaming")]
-use maud::html_stream_debug;
+use maud::html_stream;
 
 #[test]
 fn literals() {
@@ -19,7 +19,7 @@ fn literals() {
 #[cfg(feature = "streaming")]
 #[test]
 fn literals_stream() {
-    let mut s = html_stream_debug!("du\tcks" "-23" "3.14\n" "geese").wait();
+    let mut s = html_stream!("du\tcks" "-23" "3.14\n" "geese").wait();
     assert_eq!(s.next(), Some(Ok("du\tcks-233.14\ngeese")));
     assert_eq!(s.next(), None);
 }
@@ -33,7 +33,7 @@ fn escaping() {
 #[cfg(feature = "streaming")]
 #[test]
 fn escaping_stream() {
-    let mut s = html_stream_debug!("<flim&flam>").wait();
+    let mut s = html_stream!("<flim&flam>").wait();
     assert_eq!(s.next(), Some(Ok("&lt;flim&amp;flam&gt;")));
     assert_eq!(s.next(), None);
 }
@@ -126,7 +126,7 @@ fn toggle_empty_attributes_braces() {
 #[test]
 fn toggle_empty_attributes_braces_stream() {
     struct Maud { rocks: bool }
-    let mut s = html_stream_debug!(input checked?[Maud { rocks: true }.rocks] /).wait();
+    let mut s = html_stream!(input checked?[Maud { rocks: true }.rocks] /).wait();
     assert_eq!(s.next(), Some(Ok(r#"<input"#)));
     assert_eq!(s.next(), Some(Ok(r#" checked"#)));
     assert_eq!(s.next(), Some(Ok(r#">"#)));
@@ -206,7 +206,7 @@ fn toggle_classes_braces() {
 #[test]
 fn toggle_classes_braces_stream() {
     struct Maud { rocks: bool }
-    let mut s = html_stream_debug!(p.rocks[Maud { rocks: true }.rocks] { "Awesome!" }).wait();
+    let mut s = html_stream!(p.rocks[Maud { rocks: true }.rocks] { "Awesome!" }).wait();
     assert_eq!(s.next(), Some(Ok(r#"<p class=""#)));
     assert_eq!(s.next(), Some(Ok(r#"rocks"#)));
     assert_eq!(s.next(), Some(Ok(r#"">Awesome!</p>"#)));

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -20,7 +20,7 @@ fn literals() {
 #[test]
 fn literals_stream() {
     let mut s = html_stream!("du\tcks" "-23" "3.14\n" "geese").wait();
-    assert_eq!(s.next(), Some(Ok("du\tcks-233.14\ngeese")));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("du\tcks-233.14\ngeese".into()))));
     assert_eq!(s.next(), None);
 }
 
@@ -34,7 +34,7 @@ fn escaping() {
 #[test]
 fn escaping_stream() {
     let mut s = html_stream!("<flim&flam>").wait();
-    assert_eq!(s.next(), Some(Ok("&lt;flim&amp;flam&gt;")));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("&lt;flim&amp;flam&gt;".into()))));
     assert_eq!(s.next(), None);
 }
 
@@ -127,9 +127,9 @@ fn toggle_empty_attributes_braces() {
 fn toggle_empty_attributes_braces_stream() {
     struct Maud { rocks: bool }
     let mut s = html_stream!(input checked?[Maud { rocks: true }.rocks] /).wait();
-    assert_eq!(s.next(), Some(Ok(r#"<input"#)));
-    assert_eq!(s.next(), Some(Ok(r#" checked"#)));
-    assert_eq!(s.next(), Some(Ok(r#">"#)));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped(r#"<input"#.into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped(r#" checked"#.into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped(r#">"#.into()))));
     assert_eq!(s.next(), None);
 }
 
@@ -207,9 +207,9 @@ fn toggle_classes_braces() {
 fn toggle_classes_braces_stream() {
     struct Maud { rocks: bool }
     let mut s = html_stream!(p.rocks[Maud { rocks: true }.rocks] { "Awesome!" }).wait();
-    assert_eq!(s.next(), Some(Ok(r#"<p class=""#)));
-    assert_eq!(s.next(), Some(Ok(r#"rocks"#)));
-    assert_eq!(s.next(), Some(Ok(r#"">Awesome!</p>"#)));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped(r#"<p class=""#.into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped(r#"rocks"#.into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped(r#"">Awesome!</p>"#.into()))));
     assert_eq!(s.next(), None);
 }
 

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -1,8 +1,24 @@
 #![feature(proc_macro_hygiene)]
 
+extern crate futures;
 extern crate maud;
 
-use maud::{Markup, html};
+use maud::{Markup, html, html_stream_debug};
+
+#[test]
+fn stream() {
+    use futures::Stream;
+
+    let var: Box<futures::Future<Item=&str, Error=String> + Send> =
+        Box::new(futures::future::ok("test"));
+
+    let mut s = html_stream_debug!({ h1 { (var) } }).wait();
+
+    assert_eq!(s.next(), Some(Ok("<h1>")));
+    assert_eq!(s.next(), Some(Ok("test")));
+    assert_eq!(s.next(), Some(Ok("</h1>")));
+    assert_eq!(s.next(), None);
+}
 
 #[test]
 fn literals() {

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -1,23 +1,14 @@
 #![feature(proc_macro_hygiene)]
 
+#[cfg(feature = "streaming")]
 extern crate futures;
 extern crate maud;
 
+#[cfg(feature = "streaming")]
 use futures::Stream;
-use maud::{Markup, html, html_stream_debug};
-
-#[test]
-fn stream() {
-    let var: Box<futures::Future<Item=&str, Error=String> + Send> =
-        Box::new(futures::future::ok("test"));
-
-    let mut s = html_stream_debug!({ h1 { (var) } }).wait();
-
-    assert_eq!(s.next(), Some(Ok("<h1>")));
-    assert_eq!(s.next(), Some(Ok("test")));
-    assert_eq!(s.next(), Some(Ok("</h1>")));
-    assert_eq!(s.next(), None);
-}
+use maud::{Markup, html};
+#[cfg(feature = "streaming")]
+use maud::html_stream_debug;
 
 #[test]
 fn literals() {
@@ -25,6 +16,7 @@ fn literals() {
     assert_eq!(s, "du\tcks-233.14\ngeese");
 }
 
+#[cfg(feature = "streaming")]
 #[test]
 fn literals_stream() {
     let mut s = html_stream_debug!("du\tcks" "-23" "3.14\n" "geese").wait();
@@ -38,6 +30,7 @@ fn escaping() {
     assert_eq!(s, "&lt;flim&amp;flam&gt;");
 }
 
+#[cfg(feature = "streaming")]
 #[test]
 fn escaping_stream() {
     let mut s = html_stream_debug!("<flim&flam>").wait();
@@ -129,6 +122,7 @@ fn toggle_empty_attributes_braces() {
     assert_eq!(s, r#"<input checked>"#);
 }
 
+#[cfg(feature = "streaming")]
 #[test]
 fn toggle_empty_attributes_braces_stream() {
     struct Maud { rocks: bool }

--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -8,7 +8,7 @@ extern crate maud;
 use futures::Stream;
 use maud::html;
 #[cfg(feature = "streaming")]
-use maud::html_stream_debug;
+use maud::html_stream;
 
 #[test]
 fn if_expr() {
@@ -32,7 +32,7 @@ fn if_expr() {
 #[test]
 fn if_expr_stream() {
     for (number, &name) in (1..4).zip(["one", "two", "three"].iter()) {
-        let mut s = html_stream_debug! {
+        let mut s = html_stream! {
             @if number == 1 {
                 "one"
             } @else if number == 2 {
@@ -126,7 +126,7 @@ fn for_expr() {
 // #[test]
 // fn for_expr_stream() {
 //     let ponies = ["Apple Bloom", "Scootaloo", "Sweetie Belle"];
-//     let mut s = html_stream_debug! {
+//     let mut s = html_stream! {
 //         ul {
 //             @for pony in &ponies {
 //                 li { (pony) }

--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -43,7 +43,7 @@ fn if_expr_stream() {
                 "oh noes"
             }
         }.wait();
-        assert_eq!(s.next(), Some(Ok(name)));
+        assert_eq!(s.next(), Some(Ok(maud::PreEscaped(name.into()))));
         assert_eq!(s.next(), None);
     }
 }

--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -8,7 +8,7 @@ extern crate maud;
 use futures::Stream;
 use maud::html;
 #[cfg(feature = "streaming")]
-use maud::html_stream;
+use maud::{html_stream, html_stream_debug};
 
 #[test]
 fn if_expr() {
@@ -122,25 +122,31 @@ fn for_expr() {
             "</ul>"));
 }
 
-// #[cfg(feature = "streaming")]
-// #[test]
-// fn for_expr_stream() {
-//     let ponies = ["Apple Bloom", "Scootaloo", "Sweetie Belle"];
-//     let mut s = html_stream! {
-//         ul {
-//             @for pony in &ponies {
-//                 li { (pony) }
-//             }
-//         }
-//     }.wait();
+#[cfg(feature = "streaming")]
+#[test]
+fn for_expr_stream() {
+    let ponies = ["Apple Bloom", "Scootaloo", "Sweetie Belle"];
+    let mut s = html_stream_debug! {
+        ul {
+            @for pony in &ponies {
+                li { (pony) }
+            }
+        }
+    }.wait();
     
-//     assert_eq!(s.next(), Some(Ok("<ul>")));
-//     assert_eq!(s.next(), Some(Ok("<li>Apple Bloom</li>")));
-//     assert_eq!(s.next(), Some(Ok("<li>Scootaloo</li>")));
-//     assert_eq!(s.next(), Some(Ok("<li>Sweetie Belle</li>")));
-//     assert_eq!(s.next(), Some(Ok("</ul>")));
-//     assert_eq!(s.next(), None);
-// }
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("<ul>".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("<li>".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("Apple Bloom".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("</li>".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("<li>".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("Scootaloo".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("</li>".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("<li>".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("Sweetie Belle".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("</li>".into()))));
+    assert_eq!(s.next(), Some(Ok(maud::PreEscaped("</ul>".into()))));
+    assert_eq!(s.next(), None);
+}
 
 #[test]
 fn match_expr() {

--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -1,8 +1,14 @@
 #![feature(proc_macro_hygiene)]
 
+#[cfg(feature = "streaming")]
+extern crate futures;
 extern crate maud;
 
+#[cfg(feature = "streaming")]
+use futures::Stream;
 use maud::html;
+#[cfg(feature = "streaming")]
+use maud::html_stream_debug;
 
 #[test]
 fn if_expr() {
@@ -19,6 +25,26 @@ fn if_expr() {
             }
         }.into_string();
         assert_eq!(s, name);
+    }
+}
+
+#[cfg(feature = "streaming")]
+#[test]
+fn if_expr_stream() {
+    for (number, &name) in (1..4).zip(["one", "two", "three"].iter()) {
+        let mut s = html_stream_debug! {
+            @if number == 1 {
+                "one"
+            } @else if number == 2 {
+                "two"
+            } @else if number == 3 {
+                "three"
+            } @else {
+                "oh noes"
+            }
+        }.wait();
+        assert_eq!(s.next(), Some(Ok(name)));
+        assert_eq!(s.next(), None);
     }
 }
 
@@ -95,6 +121,26 @@ fn for_expr() {
             "<li>Sweetie Belle</li>",
             "</ul>"));
 }
+
+// #[cfg(feature = "streaming")]
+// #[test]
+// fn for_expr_stream() {
+//     let ponies = ["Apple Bloom", "Scootaloo", "Sweetie Belle"];
+//     let mut s = html_stream_debug! {
+//         ul {
+//             @for pony in &ponies {
+//                 li { (pony) }
+//             }
+//         }
+//     }.wait();
+    
+//     assert_eq!(s.next(), Some(Ok("<ul>")));
+//     assert_eq!(s.next(), Some(Ok("<li>Apple Bloom</li>")));
+//     assert_eq!(s.next(), Some(Ok("<li>Scootaloo</li>")));
+//     assert_eq!(s.next(), Some(Ok("<li>Sweetie Belle</li>")));
+//     assert_eq!(s.next(), Some(Ok("</ul>")));
+//     assert_eq!(s.next(), None);
+// }
 
 #[test]
 fn match_expr() {

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/lfairy/maud"
 description = "Compile-time HTML templates."
 
 [dependencies]
-futures = "0.1"
+futures = { version = "0.1", optional = true }
 literalext = { version = "0.1", default-features = false, features = ["proc-macro"] }
 matches = "0.1.6"
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
@@ -20,6 +20,9 @@ maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 [lib]
 name = "maud_macros"
 proc-macro = true
+
+[features]
+streaming = ["futures"]
 
 [badges]
 travis-ci = { repository = "lfairy/maud" }

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/lfairy/maud"
 description = "Compile-time HTML templates."
 
 [dependencies]
+futures = "0.1"
 literalext = { version = "0.1", default-features = false, features = ["proc-macro"] }
 matches = "0.1.6"
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -185,16 +185,16 @@ impl GeneratorTrait<StreamBuilder> for StreamGenerator {
     fn splice(&self, expr: TokenStream) -> TokenStream {
         let output_ident = self.output_ident.clone();
         quote!({
-            $output_ident.push($expr);
+            // $output_ident.push($expr);
             // Create a local trait alias so that autoref works
-            // trait FutureRender: maud::FutureRender {
-            //     fn __maud_render_to(&self, output_ident: &mut futures::stream::FuturesOrdered<
-            //         Box<futures::Future<Item = &str, Error = String> + Send>
-            //     >) {
-            //         maud::FutureRender::render_to(self, output_ident);
-            //     }
-            // }
-            // impl<T: maud::FutureRender> FutureRender for T {}
+            trait FutureRender: maud::FutureRender {
+                fn __maud_render_to(&self, output_ident: &mut futures::stream::FuturesOrdered<
+                    Box<futures::Future<Item = maud::Markup, Error = maud::Markup> + Send>
+                >) {
+                    maud::FutureRender::render_to(self, output_ident);
+                }
+            }
+            impl<T: maud::FutureRender> FutureRender for T {}
             $expr.to_string().__maud_render_to(&mut $output_ident);
         })
     }

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -18,23 +18,34 @@ pub fn generate(markups: Vec<Markup>, output_ident: TokenTree) -> TokenStream {
     build.finish()
 }
 
+pub fn generate_stream(markups: Vec<Markup>, output_ident: TokenTree) -> TokenStream {
+    let mut build = StreamBuilder::new(output_ident.clone());
+    StreamGenerator::new(output_ident).markups(markups, &mut build);
+    build.finish()
+}
+
+trait GeneratorTrait<T: BuilderTrait> {
+    fn markups(&self, markups: Vec<Markup>, build: &mut T);
+}
+
 struct Generator {
     output_ident: TokenTree,
 }
 
-impl Generator {
-    fn new(output_ident: TokenTree) -> Generator {
-        Generator { output_ident }
-    }
-
-    fn builder(&self) -> Builder {
-        Builder::new(self.output_ident.clone())
-    }
-
+impl GeneratorTrait<Builder> for Generator {
     fn markups(&self, markups: Vec<Markup>, build: &mut Builder) {
         for markup in markups {
             self.markup(markup, build);
         }
+    }
+}
+impl Generator {
+    fn new(output_ident: TokenTree) -> Self {
+        Self { output_ident }
+    }
+
+    fn builder(&self) -> Builder {
+        Builder::new(self.output_ident.clone())
     }
 
     fn markup(&self, markup: Markup, build: &mut Builder) {
@@ -117,6 +128,146 @@ impl Generator {
     }
 
     fn attrs(&self, attrs: Attrs, build: &mut Builder) {
+        for Attribute { name, attr_type } in desugar_attrs(attrs) {
+            match attr_type {
+                AttrType::Normal { value } => {
+                    build.push_str(" ");
+                    self.name(name, build);
+                    build.push_str("=\"");
+                    self.markup(value, build);
+                    build.push_str("\"");
+                },
+                AttrType::Empty { toggler: None } => {
+                    build.push_str(" ");
+                    self.name(name, build);
+                },
+                AttrType::Empty { toggler: Some(toggler) } => {
+                    let head = desugar_toggler(toggler);
+                    build.push_tokens({
+                        let mut build = self.builder();
+                        build.push_str(" ");
+                        self.name(name, &mut build);
+                        let body = build.finish();
+                        quote!($head { $body })
+                    })
+                },
+            }
+        }
+    }
+
+    fn special(&self, Special { head, body, .. }: Special) -> TokenStream {
+        let body = self.block(body);
+        quote!($head $body)
+    }
+
+    fn match_arm(&self, MatchArm { head, body }: MatchArm) -> TokenStream {
+        let body = self.block(body);
+        quote!($head $body)
+    }
+}
+
+struct StreamGenerator {
+    output_ident: TokenTree,
+}
+
+impl GeneratorTrait<StreamBuilder> for StreamGenerator {
+    fn markups(&self, markups: Vec<Markup>, build: &mut StreamBuilder) {
+        for markup in markups {
+            self.markup(markup, build);
+        }
+    }
+}
+
+impl StreamGenerator {
+    fn new(output_ident: TokenTree) -> Self {
+        Self { output_ident }
+    }
+
+    fn builder(&self) -> StreamBuilder {
+        StreamBuilder::new(self.output_ident.clone())
+    }
+
+    fn markup(&self, markup: Markup, build: &mut StreamBuilder) {
+        match markup {
+            Markup::Block(Block { markups, outer_span }) => {
+                if markups.iter().any(|markup| matches!(*markup, Markup::Let { .. })) {
+                    build.push_tokens(self.block(Block { markups, outer_span }));
+                } else {
+                    self.markups(markups, build);
+                }
+            },
+            Markup::Literal { content, .. } => build.push_escaped(&content),
+            Markup::Symbol { symbol } => self.name(symbol, build),
+            Markup::Splice { expr, .. } => build.push_tokens(self.splice(expr)),
+            Markup::Element { name, attrs, body } => self.element(name, attrs, body, build),
+            Markup::Let { tokens, .. } => build.push_tokens(tokens),
+            Markup::Special { segments } => {
+                for segment in segments {
+                    build.push_tokens(self.special(segment));
+                }
+            },
+            Markup::Match { head, arms, arms_span, .. } => {
+                build.push_tokens({
+                    let body = arms
+                        .into_iter()
+                        .map(|arm| self.match_arm(arm))
+                        .collect();
+                    let mut body = TokenTree::Group(Group::new(Delimiter::Brace, body));
+                    body.set_span(arms_span);
+                    quote!($head $body)
+                });
+            },
+        }
+    }
+
+    fn block(&self, Block { markups, outer_span }: Block) -> TokenStream {
+        let mut build = self.builder();
+        self.markups(markups, &mut build);
+        let mut block = TokenTree::Group(Group::new(Delimiter::Brace, build.finish()));
+        block.set_span(outer_span);
+        TokenStream::from(block)
+    }
+
+    fn splice(&self, expr: TokenStream) -> TokenStream {
+        let output_ident = self.output_ident.clone();
+        quote!({
+            $output_ident.push($expr);
+            // Create a local trait alias so that autoref works
+            // trait Render: maud::Render {
+            //     fn __maud_render_to(&self, output_ident: &mut String) {
+            //         maud::Render::render_to(self, output_ident);
+            //     }
+            // }
+            // impl<T: maud::Render> Render for T {}
+            // $expr.__maud_render_to(&mut $output_ident);
+        })
+    }
+
+    fn element(
+        &self,
+        name: TokenStream,
+        attrs: Attrs,
+        body: ElementBody,
+        build: &mut StreamBuilder,
+    ) {
+        build.push_str("<");
+        self.name(name.clone(), build);
+        self.attrs(attrs, build);
+        build.push_str(">");
+        if let ElementBody::Block { block } = body {
+            self.markups(block.markups, build);
+            build.push_str("</");
+            self.name(name, build);
+            build.push_str(">");
+        }
+    }
+
+    fn name(&self, name: TokenStream, build: &mut StreamBuilder) {
+        let string = name.into_iter().map(|token| token.to_string()).collect::<String>();
+        build.push_escaped(&string);
+    }
+
+    fn attrs(&self, attrs: Attrs, build: &mut StreamBuilder) {
         for Attribute { name, attr_type } in desugar_attrs(attrs) {
             match attr_type {
                 AttrType::Normal { value } => {
@@ -243,15 +394,24 @@ fn desugar_toggler(Toggler { mut cond, cond_span }: Toggler) -> TokenStream {
 
 ////////////////////////////////////////////////////////
 
+trait BuilderTrait {
+    fn new(output_ident: TokenTree) -> Self;
+    fn push_str(&mut self, string: &str);
+    fn push_escaped(&mut self, string: &str);
+    fn push_tokens<T: IntoIterator<Item=TokenTree>>(&mut self, tokens: T);
+    fn cut(&mut self);
+    fn finish(mut self) -> TokenStream;
+}
+
 struct Builder {
     output_ident: TokenTree,
     tokens: Vec<TokenTree>,
     tail: String,
 }
 
-impl Builder {
-    fn new(output_ident: TokenTree) -> Builder {
-        Builder {
+impl BuilderTrait for Builder {
+    fn new(output_ident: TokenTree) -> Self {
+        Self {
             output_ident,
             tokens: Vec::new(),
             tail: String::new(),
@@ -280,6 +440,54 @@ impl Builder {
             let output_ident = self.output_ident.clone();
             let string = TokenTree::Literal(Literal::string(&self.tail));
             quote!($output_ident.push_str($string);)
+        };
+        self.tail.clear();
+        self.tokens.extend(push_str_expr);
+    }
+
+    fn finish(mut self) -> TokenStream {
+        self.cut();
+        self.tokens.into_iter().collect()
+    }
+}
+
+struct StreamBuilder {
+    output_ident: TokenTree,
+    tokens: Vec<TokenTree>,
+    tail: String,
+}
+
+impl BuilderTrait for StreamBuilder {
+    fn new(output_ident: TokenTree) -> Self {
+        Self {
+            output_ident,
+            tokens: Vec::new(),
+            tail: String::new(),
+        }
+    }
+
+    fn push_str(&mut self, string: &str) {
+        self.tail.push_str(string);
+    }
+
+    fn push_escaped(&mut self, string: &str) {
+        use std::fmt::Write;
+        Escaper::new(&mut self.tail).write_str(string).unwrap();
+    }
+
+    fn push_tokens<T: IntoIterator<Item=TokenTree>>(&mut self, tokens: T) {
+        self.cut();
+        self.tokens.extend(tokens);
+    }
+
+    fn cut(&mut self) {
+        if self.tail.is_empty() {
+            return;
+        }
+        let push_str_expr = {
+            let output_ident = self.output_ident.clone();
+            let string = TokenTree::Literal(Literal::string(&self.tail));
+            quote!($output_ident.push(Box::new(futures::future::ok($string)));)
         };
         self.tail.clear();
         self.tokens.extend(push_str_expr);

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -187,13 +187,15 @@ impl GeneratorTrait<StreamBuilder> for StreamGenerator {
         quote!({
             $output_ident.push($expr);
             // Create a local trait alias so that autoref works
-            // trait Render: maud::Render {
-            //     fn __maud_render_to(&self, output_ident: &mut String) {
-            //         maud::Render::render_to(self, output_ident);
+            // trait FutureRender: maud::FutureRender {
+            //     fn __maud_render_to(&self, output_ident: &mut futures::stream::FuturesOrdered<
+            //         Box<futures::Future<Item = &str, Error = String> + Send>
+            //     >) {
+            //         maud::FutureRender::render_to(self, output_ident);
             //     }
             // }
-            // impl<T: maud::Render> Render for T {}
-            // $expr.__maud_render_to(&mut $output_ident);
+            // impl<T: maud::FutureRender> FutureRender for T {}
+            $expr.to_string().__maud_render_to(&mut $output_ident);
         })
     }
 }

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -18,6 +18,7 @@ pub fn generate(markups: Vec<Markup>, output_ident: TokenTree) -> TokenStream {
     build.finish()
 }
 
+#[cfg(feature = "streaming")]
 pub fn generate_stream(markups: Vec<Markup>, output_ident: TokenTree) -> TokenStream {
     let mut build = StreamBuilder::new(output_ident.clone());
     StreamGenerator::new(output_ident).markups(markups, &mut build);
@@ -170,10 +171,12 @@ impl Generator {
     }
 }
 
+#[cfg(feature = "streaming")]
 struct StreamGenerator {
     output_ident: TokenTree,
 }
 
+#[cfg(feature = "streaming")]
 impl GeneratorTrait<StreamBuilder> for StreamGenerator {
     fn builder(&self) -> StreamBuilder {
         StreamBuilder::new(self.output_ident.clone())
@@ -195,6 +198,7 @@ impl GeneratorTrait<StreamBuilder> for StreamGenerator {
     }
 }
 
+#[cfg(feature = "streaming")]
 impl StreamGenerator {
     fn new(output_ident: TokenTree) -> Self {
         Self { output_ident }
@@ -346,12 +350,14 @@ impl BuilderTrait for Builder {
     }
 }
 
+#[cfg(feature = "streaming")]
 struct StreamBuilder {
     output_ident: TokenTree,
     tokens: Vec<TokenTree>,
     tail: String,
 }
 
+#[cfg(feature = "streaming")]
 impl BuilderTrait for StreamBuilder {
     fn new(output_ident: TokenTree) -> Self {
         Self {

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -390,7 +390,7 @@ impl BuilderTrait for StreamBuilder {
         let push_str_expr = {
             let output_ident = self.output_ident.clone();
             let string = TokenTree::Literal(Literal::string(&self.tail));
-            quote!($output_ident.push(Box::new(futures::future::ok($string)));)
+            quote!($output_ident.push(Box::new(futures::future::ok(maud::PreEscaped($string.into()))));)
         };
         self.tail.clear();
         self.tokens.extend(push_str_expr);

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -295,7 +295,7 @@ trait BuilderTrait {
     fn push_escaped(&mut self, string: &str);
     fn push_tokens<T: IntoIterator<Item=TokenTree>>(&mut self, tokens: T);
     fn cut(&mut self);
-    fn finish(mut self) -> TokenStream;
+    fn finish(self) -> TokenStream;
 }
 
 struct Builder {

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -81,7 +81,7 @@ fn expand_stream(input: TokenStream) -> TokenStream {
         extern crate maud;
         extern crate futures;
         let mut $output_ident: futures::stream::FuturesOrdered<
-            Box<futures::Future<Item = &str, Error = &str> + Send>
+            Box<futures::Future<Item = maud::Markup, Error = maud::Markup> + Send>
         > = futures::stream::FuturesOrdered::new();
         $stmts
         $output_ident

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -36,11 +36,13 @@ pub fn html_debug(input: TokenStream) -> TokenStream {
     expr
 }
 
+#[cfg(feature = "streaming")]
 #[proc_macro]
 pub fn html_stream(input: TokenStream) -> TokenStream {
     expand_stream(input)
 }
 
+#[cfg(feature = "streaming")]
 #[proc_macro]
 pub fn html_stream_debug(input: TokenStream) -> TokenStream {
     let expr = expand_stream(input);
@@ -67,6 +69,7 @@ fn expand(input: TokenStream) -> TokenStream {
     })
 }
 
+#[cfg(feature = "streaming")]
 fn expand_stream(input: TokenStream) -> TokenStream {
     let output_ident = TokenTree::Ident(Ident::new("__maud_output", Span::def_site()));
     // Heuristic: the size of the resulting markup tends to correlate with the

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -72,8 +72,6 @@ fn expand(input: TokenStream) -> TokenStream {
 #[cfg(feature = "streaming")]
 fn expand_stream(input: TokenStream) -> TokenStream {
     let output_ident = TokenTree::Ident(Ident::new("__maud_output", Span::def_site()));
-    // Heuristic: the size of the resulting markup tends to correlate with the
-    // code size of the template itself
     let markups = match parse::parse(input) {
         Ok(markups) => markups,
         Err(()) => Vec::new(),
@@ -83,10 +81,9 @@ fn expand_stream(input: TokenStream) -> TokenStream {
         extern crate maud;
         extern crate futures;
         let mut $output_ident: futures::stream::FuturesOrdered<
-            Box<futures::Future<Item = &str, Error = String> + Send>
+            Box<futures::Future<Item = &str, Error = &str> + Send>
         > = futures::stream::FuturesOrdered::new();
         $stmts
         $output_ident
-        // maud::PreEscaped($output_ident)
     })
 }


### PR DESCRIPTION
Quick-and-dirty implementation, contains lots of duplicate code. Will try to clean it up in the upcoming days.

Todo:
 - [x] Reduce code duplication
 - [ ] Handle escaping
 - [ ] Implement conversions (so you aren't required to pass futures)
 - [ ] More tests
 - [ ] Avoid boxing (if possible)
 - [x] Make it a feature (off by default)

Closes #149.