### PR TITLE
Added warning when elements have keyword names

### DIFF
--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -154,7 +154,7 @@ impl Parser {
                 match ident_string.as_str() {
                     "if" | "while" | "for" | "match" | "let" => {
                         ident.span()
-                            .warning(format!("found keyword `{}` - should this be a `@{}`?", ident_string, ident_string))
+                            .warning(format!("found keyword `{0}` - should this be a `@{0}`?", ident_string))
                             .emit();
                     }
                     _ => {}

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -148,7 +148,17 @@ impl Parser {
                 }
             },
             // Element
-            TokenTree::Ident(_) => {
+            TokenTree::Ident(ident) => {
+                let ident_string = ident.to_string();
+                // Is this a keyword that's missing a '@'?
+                match ident_string.as_str() {
+                    "if" | "while" | "for" | "match" | "let" => {
+                        ident.span()
+                            .warning(format!("found keyword `{}` - should this be a `@{}`?", ident_string, ident_string))
+                            .emit();
+                    }
+                    _ => {}
+                }
                 // `.try_namespaced_name()` should never fail as we've
                 // already seen an `Ident`
                 let name = self.try_namespaced_name().expect("identifier");


### PR DESCRIPTION
Fixes #91.
To avoid erroneously preventing elements which are actually meant to be
called `if` from being used, this is only a warning, with a suggestion
of the template syntax.