### PR TITLE
Enable scoped lint feature to fix scoped lint use

### DIFF
--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(proc_macro_hygiene)]
 #![feature(proc_macro_quote)]
 #![feature(proc_macro_span)]
+#![feature(tool_lints)]
 
 #![doc(html_root_url = "https://docs.rs/maud_macros/0.18.1")]
 


### PR DESCRIPTION
```
error[E0658]: scoped lint `clippy::needless_pass_by_value` is experimental (see issue #44690)
  --> /home/sanmai/.cargo/git/checkouts/maud-588f745ae3a2d730/365d0ab/maud_macros/src/lib.rs:11:10
   |
11 | #![allow(clippy::needless_pass_by_value)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(tool_lints)] to the crate attributes to enable
```