### PR TITLE
Set default content-type html for actix feature

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -203,7 +203,9 @@ mod actix_support {
         type Item = HttpResponse;
         type Error = Error;
         fn respond_to<S>(self, _req: &HttpRequest<S>) -> Result<Self::Item, Self::Error> {
-            Ok(HttpResponse::Ok().body(self.0))
+            Ok(HttpResponse::Ok()
+               .content_type("text/html; charset=utf-8")
+               .body(self.0))
         }
     }
 }


### PR DESCRIPTION
Whenever I used `@for` of any kind in the returned Markup, Actix detected the content type as `application/octet-stream`, which prevented the browser from displaying it as html.

This PR explicitly sets content-type to "text/html" in the Actix feature handler, and fixes the above issue.  I don't see any reason why this would be incorrect, because all Markup instances are html.  One adjustment might be to explicitly set encoding to utf-8. Let me know if you'd prefer that.