### PR TITLE
Bumped actix-web version

### DIFF
--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -16,7 +16,7 @@ maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 maud_macros = { version = "0.20.0", path = "../maud_macros" }
 iron = { version = ">= 0.5.1, < 0.7.0", optional = true }
 rocket = { version = ">= 0.3, < 0.5", optional = true }
-actix-web = { version = ">= 0.6.12, < 0.8.0", optional = true }
+actix-web = { version = "1.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 compiletest_rs = { version = "0.3.19", features = ["stable"] }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -197,9 +197,9 @@ mod actix_support {
     use actix_web::{Responder, HttpResponse, HttpRequest, Error};
 
     impl Responder for PreEscaped<String> {
-        type Item = HttpResponse;
         type Error = Error;
-        fn respond_to<S>(self, _req: &HttpRequest<S>) -> Result<Self::Item, Self::Error> {
+        type Future = Result<HttpResponse, Self::Error>;
+        fn respond_to(self, _req: &HttpRequest) -> Self::Future {
             Ok(HttpResponse::Ok()
                .content_type("text/html; charset=utf-8")
                .body(self.0))


### PR DESCRIPTION
The default features have also been disabled since they're unused by maud and caused issues when another dependency uses a different version of ring than actix-web.